### PR TITLE
fix: strip unnecessary leading path from source of scp on GHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
           key: ${{ secrets.KEY }}
           source: "frontend/index.html"
           target: "/var/www/html/"
+          strip_components: 1
 
       - name: Deploy BackEnd
         uses: appleboy/scp-action@v0.1.7
@@ -30,3 +31,4 @@ jobs:
           key: ${{ secrets.KEY }}
           source: "backend/myapi.py"
           target: "/home/ubuntu/myapp/"
+          strip_components: 1


### PR DESCRIPTION
From the appleboy/scp-actions documentation:
https://github.com/appleboy/scp-action

![2024-10-05_11-15](https://github.com/user-attachments/assets/b46be2ad-f386-4a85-8b9b-ebc924af2a1b)
